### PR TITLE
Redirect bad output (e.g. warnings) to stderr but keep processing

### DIFF
--- a/pmd.groovy
+++ b/pmd.groovy
@@ -107,7 +107,6 @@ while ((line = reader.readLine()) != null) {
     System.out.println(line)
   } else {
     System.err.println(line)
-    System.exit(-1)
   }
 }
 

--- a/test.groovy
+++ b/test.groovy
@@ -41,10 +41,11 @@ def abortOnBadConfig() {
 }
 
 def handleBadOutput() {
+  // Redirect bad output (e.g. warnings) to stderr but keep processing
   def (proc, out, err) = execute("/usr/src/app/pmd.groovy --codeFolder=/code/test --configFile=/code/test/config.problematic_rules.json")
 
   assert !err.toString().isEmpty()
-  assert proc.exitValue() != 0
+  assert proc.exitValue() == 0
 }
 
 def engineCheckList() {


### PR DESCRIPTION
@wfleming Merged https://github.com/codeclimate/codeclimate-pmd/pull/9 and created this one just for the concern.

I think it makes sense to redirect those non-issues entries and not abort. But I worry a bit about unknown scenarios, though.
The problem I see in the CLI is that the user will only have a clue about this warning if `CODECLIMATE_DEBUG` is on.
