### PR TITLE
Upgrade codeclimate-pmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER "Code Climate <hello@codeclimate.com>"
 USER root
 
 RUN apk update && \
-    apk add ca-certificates wget curl jq && \
+    apk add ca-certificates wget curl jq bash && \
     update-ca-certificates
 
 RUN adduser -u 9000 -D app

--- a/bin/install-pmd.sh
+++ b/bin/install-pmd.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 LIB_DIR=/usr/src/app/lib
 
 download_pmd() {
-  URL="https://github.com/pmd/pmd/releases/download/pmd_releases/6.0.1/pmd-bin-6.0.1.zip"
+  URL="https://github.com/pmd/pmd/releases/download/pmd_releases/6.7.0/pmd-bin-6.7.0.zip"
   wget -O pmd.zip $URL
 }
 


### PR DESCRIPTION
- We've had some requests to upgrade the `codeclimate-pmd` engine
- This upgrades the engine to the latest version: `6.7.0`
- Tested this against a handful of repos since we've jumped a few versions since the last upgrade