### PR TITLE
Adds support for Apex classes (Salesforce)

### DIFF
--- a/src/Config.groovy
+++ b/src/Config.groovy
@@ -78,7 +78,7 @@ class Config {
     def i = files.iterator()
     while(i.hasNext()) {
       def name = i.next()
-      if(!name.endsWith(".java")) {
+      if(!name.endsWith(".java") && !name.endsWith(".cls")) {
         i.remove()
       }
     }


### PR DESCRIPTION
Currently, Salesforce developers cannot use CodeClimate despite CodeClimate having PMD as a plugin. This is because the PMD plugin filters out all files that are not Java (`.java`). This patch allows for the Apex class extension to be processed as well (`.cls`).

Related to #26 