### PR TITLE
Update pmd to 6.32.0

### DIFF
--- a/bin/install-pmd.sh
+++ b/bin/install-pmd.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 LIB_DIR=/usr/src/app/lib
 
 download_pmd() {
-  URL="https://github.com/pmd/pmd/releases/download/pmd_releases/6.7.0/pmd-bin-6.7.0.zip"
+  URL="https://github.com/pmd/pmd/releases/download/pmd_releases/6.32.0/pmd-bin-6.32.0.zip"
   wget -O pmd.zip $URL
 }
 


### PR DESCRIPTION
pmd 6.7.0 is released in Sep 2, 2018 which is too old. It doesn't even include the rule that an old project like fdroidclient needs: https://gitlab.com/proletarius101/fdroidclient/-/jobs/1084197345